### PR TITLE
Add Support for Keypad Button Presses

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -549,6 +549,7 @@ class Keypad(LutronEntity):
   (and drop them on the floor).
   """
   CMD_TYPE = 'DEVICE'
+  ACTION_PRESS = 3
 
   def __init__(self, lutron, name, integration_id):
     """Initializes the Keypad object."""
@@ -560,6 +561,11 @@ class Keypad(LutronEntity):
     """Adds a button that's part of this keypad. We'll use this to
     dispatch button events."""
     self._buttons.append(button)
+
+  def press(self, button):
+    """Send a press command to a button on the keypad."""
+    if button in self._buttons:
+      self._lutron.send(Lutron.OP_EXECUTE, Keypad.CMD_TYPE, self._integration_id, button._num, Keypad.ACTION_PRESS)
 
   @property
   def buttons(self):


### PR DESCRIPTION
Enable a keypad press on a specific button to send
the command to the Main Repeater to trigger the button