### PR TITLE
Fix string representations of the Button class

### DIFF
--- a/pylutron/__init__.py
+++ b/pylutron/__init__.py
@@ -519,12 +519,13 @@ class Button(object):
 
   def __str__(self):
     """Pretty printed string value of the Button object."""
-    return 'Button name: "%s" num: %d action: "%s"' % (
-        self._name, self._num, self._action)
+    return 'Button name: "%s" num: %d type: "%s" direction: "%s"' % (
+        self._name, self._num, self._button_type, self._direction)
 
   def __repr__(self):
     """String representation of the Button object."""
-    return str({'name': self._name, 'num': self._num, 'action': self._action})
+    return str({'name': self._name, 'num': self._num,
+               'type': self._button_type, 'direction': self._direction})
 
   @property
   def name(self):


### PR DESCRIPTION
The Button class was returning `self._action` as part of its
`__str__` and `__repr__` implementations.  The `_action` attribute
does not exist on the Button class, resulting in an `AttributeError`.

This commit updates the `__str__` and `__repr__` implementations
to return the current Button attributes.